### PR TITLE
added 7 testcases to cover main

### DIFF
--- a/symbi/main/tests.py
+++ b/symbi/main/tests.py
@@ -28,7 +28,7 @@ class MainViewArchivedPostTest(TestCase):
         self.client.login(username="testuser", password="testpassword")
 
         # Create an archived post
-        archived_post = ActivityPost.objects.create(
+        ActivityPost.objects.create(
             poster=self.user,
             title="Archived Post",
             description="This post is archived.",
@@ -50,7 +50,7 @@ class MainViewPostedPostTest(TestCase):
         self.client.login(username="testuser", password="testpassword")
 
         # Create a posted post
-        posted_post = ActivityPost.objects.create(
+        ActivityPost.objects.create(
             poster=self.user,
             title="Posted Post",
             description="This post is posted.",
@@ -72,7 +72,7 @@ class MainViewDraftedPostTest(TestCase):
         self.client.login(username="testuser", password="testpassword")
 
         # Create a drafted post
-        drafted_post = ActivityPost.objects.create(
+        ActivityPost.objects.create(
             poster=self.user,
             title="Drafted Post",
             description="This post is drafted.",
@@ -95,7 +95,7 @@ class MainViewMultiplePostTests(TestCase):
         self.client.login(username="testuser", password="testpassword")
 
         # Create an archived post
-        archived_post = ActivityPost.objects.create(
+        ActivityPost.objects.create(
             poster=self.user,
             title="Archived Post",
             description="This post is archived.",
@@ -103,7 +103,7 @@ class MainViewMultiplePostTests(TestCase):
         )
 
         # Create a posted post
-        posted_post = ActivityPost.objects.create(
+        ActivityPost.objects.create(
             poster=self.user,
             title="Posted Post",
             description="This post is posted.",
@@ -111,7 +111,7 @@ class MainViewMultiplePostTests(TestCase):
         )
 
         # Create a drafted post
-        drafted_post = ActivityPost.objects.create(
+        ActivityPost.objects.create(
             poster=self.user,
             title="Drafted Post",
             description="This post is drafted.",
@@ -174,7 +174,7 @@ class ConnectionTests(TestCase):
         connected_user = SocialUser.objects.create_user(
             username="connecteduser", password="testpassword"
         )
-        connection = Connection.objects.create(
+        Connection.objects.create(
             userA=self.user,
             userB=connected_user,
             status=Connection.ConnectionStatus.CONNECTED,

--- a/symbi/main/tests.py
+++ b/symbi/main/tests.py
@@ -1,3 +1,189 @@
-# from django.test import TestCase
+from django.test import TestCase
+from django.urls import reverse
+from posts.models import ActivityPost
+from django.utils import timezone
+from .models import SocialUser, Connection, Notification
+
 
 # Create your tests here.
+class MainViewNoPostTest(TestCase):
+    def setUp(self):
+        self.user = SocialUser.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.client.login(username="testuser", password="testpassword")
+
+    def test_main_view_no_post(self):
+        response = self.client.get(reverse("main:home"))
+        self.assertEqual(response.status_code, 200)
+        # Check that the message "No posts are available." is shown in home page when there is no post
+        self.assertContains(response, "No posts are available.")
+
+
+class MainViewArchivedPostTest(TestCase):
+    def setUp(self):
+        self.user = SocialUser.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.client.login(username="testuser", password="testpassword")
+
+        # Create an archived post
+        archived_post = ActivityPost.objects.create(
+            poster=self.user,
+            title="Archived Post",
+            description="This post is archived.",
+            status=ActivityPost.PostStatus.ARCHIVED,
+        )
+
+    def test_main_view_archived_post(self):
+        response = self.client.get(reverse("main:home"))
+        self.assertEqual(response.status_code, 200)
+        # Check that the archived post is not shown in home page
+        self.assertNotContains(response, "Archived Post")
+
+
+class MainViewPostedPostTest(TestCase):
+    def setUp(self):
+        self.user = SocialUser.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.client.login(username="testuser", password="testpassword")
+
+        # Create a posted post
+        posted_post = ActivityPost.objects.create(
+            poster=self.user,
+            title="Posted Post",
+            description="This post is posted.",
+            status=ActivityPost.PostStatus.ACTIVE,
+        )
+
+    def test_main_view_posted_post(self):
+        response = self.client.get(reverse("main:home"))
+        self.assertEqual(response.status_code, 200)
+        # Check that the posted post is present in the response
+        self.assertContains(response, "Posted Post")
+
+
+class MainViewDraftedPostTest(TestCase):
+    def setUp(self):
+        self.user = SocialUser.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.client.login(username="testuser", password="testpassword")
+
+        # Create a drafted post
+        drafted_post = ActivityPost.objects.create(
+            poster=self.user,
+            title="Drafted Post",
+            description="This post is drafted.",
+            status=ActivityPost.PostStatus.DRAFT,
+        )
+
+    def test_main_view_drafted_post(self):
+        response = self.client.get(reverse("main:home"))
+        self.assertEqual(response.status_code, 200)
+        # Check that the drafted post is not present in the response
+        self.assertNotContains(response, "Drafted Post")
+
+
+class MainViewMultiplePostTests(TestCase):
+    def setUp(self):
+        # Create a user
+        self.user = SocialUser.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.client.login(username="testuser", password="testpassword")
+
+        # Create an archived post
+        archived_post = ActivityPost.objects.create(
+            poster=self.user,
+            title="Archived Post",
+            description="This post is archived.",
+            status=ActivityPost.PostStatus.ARCHIVED,
+        )
+
+        # Create a posted post
+        posted_post = ActivityPost.objects.create(
+            poster=self.user,
+            title="Posted Post",
+            description="This post is posted.",
+            status=ActivityPost.PostStatus.ACTIVE,
+        )
+
+        # Create a drafted post
+        drafted_post = ActivityPost.objects.create(
+            poster=self.user,
+            title="Drafted Post",
+            description="This post is drafted.",
+            status=ActivityPost.PostStatus.DRAFT,
+        )
+
+    def test_main_view_multiple_post(self):
+        response = self.client.get(reverse("main:home"))
+        self.assertEqual(response.status_code, 200)
+        # Check that the only Posted Post is displayed
+        self.assertNotContains(response, "Drafted Post")
+        self.assertContains(response, "Posted Post")
+        self.assertNotContains(response, "Archived Post")
+
+
+class NotificationViewTests(TestCase):
+    def setUp(self):
+        # Create two users
+        self.user1 = SocialUser.objects.create_user(
+            username="user1", password="testpassword1"
+        )
+        self.user2 = SocialUser.objects.create_user(
+            username="user2", password="testpassword2"
+        )
+
+        # Log in the users
+        self.client.login(username="user1", password="testpassword1")
+
+        # Create a connection request notification
+        self.connection_request_notification = Notification.objects.create(
+            recipient_user=self.user1,
+            from_user=self.user2,
+            content="Connection request from user2",
+            type=Notification.NotificationType.CONNECTION_REQUEST,
+            timestamp=timezone.now(),
+        )
+
+    def test_notification_view_connection_request(self):
+        # Test accessing the notifications view
+        response = self.client.get(
+            reverse("main:notifications", kwargs={"pk": self.user1.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Connection request from user2")
+        self.assertContains(response, "Accept")
+
+
+class ConnectionTests(TestCase):
+    def setUp(self):
+        # Create a user
+        self.user = SocialUser.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+
+        # Log in the user
+        self.client.login(username="testuser", password="testpassword")
+
+    def test_connections_view(self):
+        # Create a connection
+        connected_user = SocialUser.objects.create_user(
+            username="connecteduser", password="testpassword"
+        )
+        connection = Connection.objects.create(
+            userA=self.user,
+            userB=connected_user,
+            status=Connection.ConnectionStatus.CONNECTED,
+            timestamp=timezone.now(),
+        )
+
+        # Test accessing the connections view
+        response = self.client.get(
+            reverse("main:connections", kwargs={"pk": self.user.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "connecteduser")


### PR DESCRIPTION
5 test cases for the home page list for the following situations: 1) no post
2) only 1 archive post
3) only 1 active post
4) only 1 draft post
5) 1 archive post, 1 active post, and 1 draft post

added 1 test case for notification
- created a notification of connection request and test if it is shown in the notification page.
- also show test if "accept" is shown in notification page

added 1 test case for connection:
- created 2 users - self.user and connected user
- check if connected_user is shown on the connection page of self.user